### PR TITLE
extract-dependencies implemented in Haskell

### DIFF
--- a/extract-dependencies/.gitignore
+++ b/extract-dependencies/.gitignore
@@ -1,1 +1,2 @@
 .stack-work/
+TAGS

--- a/extract-dependencies/.gitignore
+++ b/extract-dependencies/.gitignore
@@ -1,0 +1,1 @@
+.stack-work/

--- a/extract-dependencies/LICENSE
+++ b/extract-dependencies/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015 André Barnabá
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/extract-dependencies/Setup.hs
+++ b/extract-dependencies/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/extract-dependencies/extract-dependencies.cabal
+++ b/extract-dependencies/extract-dependencies.cabal
@@ -19,4 +19,5 @@ executable extract-dependencies
                      , wreq >= 0.4 && < 1
                      , lens >= 4.12 && < 5
                      , lens-aeson >= 1.0 && < 2
+                     , bytestring >= 0.10 && < 1
   default-language:    Haskell2010

--- a/extract-dependencies/extract-dependencies.cabal
+++ b/extract-dependencies/extract-dependencies.cabal
@@ -1,0 +1,23 @@
+name:                extract-dependencies
+version:             0.1.0.0
+synopsis:            Given a hackage package outputs the list of its dependencies.
+homepage:            https://github.com/yamadapc/stack-run-auto/extract-dependencies
+license:             MIT
+license-file:        LICENSE
+author:              André Barnabá
+maintainer:          asakeron@gmail.com
+copyright:           2015 André Barnabá
+category:            Development
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable extract-dependencies
+  hs-source-dirs:      src
+  main-is:             Main.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
+  build-depends:       base >= 4.8 && < 5
+                     , html-conduit >= 1.2 && < 2
+                     , xml-conduit >= 1.3 && < 2
+                     , bytestring >= 0.10 && < 1
+                     , text >= 1.2 && < 2
+  default-language:    Haskell2010

--- a/extract-dependencies/extract-dependencies.cabal
+++ b/extract-dependencies/extract-dependencies.cabal
@@ -20,4 +20,5 @@ executable extract-dependencies
                      , lens >= 4.12 && < 5
                      , lens-aeson >= 1.0 && < 2
                      , bytestring >= 0.10 && < 1
+                     , Cabal >= 1.22 && < 2
   default-language:    Haskell2010

--- a/extract-dependencies/extract-dependencies.cabal
+++ b/extract-dependencies/extract-dependencies.cabal
@@ -16,8 +16,7 @@ executable extract-dependencies
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:       base >= 4.8 && < 5
-                     , html-conduit >= 1.2 && < 2
-                     , xml-conduit >= 1.3 && < 2
-                     , bytestring >= 0.10 && < 1
-                     , text >= 1.2 && < 2
+                     , wreq >= 0.4 && < 1
+                     , lens >= 4.12 && < 5
+                     , lens-aeson >= 1.0 && < 2
   default-language:    Haskell2010

--- a/extract-dependencies/src/Main.hs
+++ b/extract-dependencies/src/Main.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import           Control.Lens       ((&), (.~), (^..))
+import           Control.Lens       ((&), (.~), (^..), (^.))
 import           Data.Aeson.Lens    (key, values, _Integral)
 import           Network.Wreq
 import           System.Environment (getArgs)
+import           Data.ByteString.Lazy.Char8 (ByteString)
 
 getLatestRevision :: String -> IO Integer
 getLatestRevision package =
@@ -12,5 +13,12 @@ getLatestRevision package =
   where opt = defaults & header "Accept" .~ ["application/json"]
         uri = "http://hackage.haskell.org/package/" ++ package ++ "/revisions/"
 
+getPackageRevision :: String -> Integer -> IO ByteString
+getPackageRevision package revision =
+  (^. responseBody) <$> get uri
+  where uri = "http://hackage.haskell.org/package/" ++ package ++ "/revision/" ++ show revision
+
 main :: IO ()
-main = getArgs >>= getLatestRevision . head >>= print
+main = do
+  package <- head <$> getArgs
+  getLatestRevision package >>= getPackageRevision package >>= print

--- a/extract-dependencies/src/Main.hs
+++ b/extract-dependencies/src/Main.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import qualified Data.ByteString.Lazy.Char8 as L
+import qualified Data.Text                  as T
+import           Text.HTML.DOM              (parseLBS)
+import           Text.XML.Cursor            (attribute, attributeIs, element,
+                                             fromDocument, ($//), (&/), (&|))
+
+main :: IO ()
+main =
+  (fromDocument . parseLBS) <$> L.getContents
+                            >>= (\cursor -> display $ cursor $// selector &| extract)
+  where selector = element "td" &/ attributeIs "id" "detailed-dependencies" &/
+                   element "ul" &/ element "li" &/ element "a"
+        extract = snd . T.breakOnEnd "/package/" . T.concat . attribute "href"
+        display = mapM_ (putStrLn . T.unpack)

--- a/extract-dependencies/src/Main.hs
+++ b/extract-dependencies/src/Main.hs
@@ -1,11 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
-import           Control.Lens       ((&), (.~), (^..), (^.))
-import           Data.Aeson.Lens    (key, values, _Integral)
+import           Control.Lens                          ((&), (.~), (^.), (^..))
+import           Control.Monad                         (forM_)
+import           Data.Aeson.Lens                       (key, values, _Integral)
+import           Data.ByteString.Lazy.Char8            (ByteString)
+import qualified Data.ByteString.Lazy.Char8            as L
+import           Distribution.Package                  (Dependency (..),
+                                                        unPackageName)
+import           Distribution.PackageDescription       (condLibrary,
+                                                        condTreeConstraints)
+import           Distribution.PackageDescription.Parse (ParseResult (..),
+                                                        parsePackageDescription)
 import           Network.Wreq
-import           System.Environment (getArgs)
-import           Data.ByteString.Lazy.Char8 (ByteString)
+import           System.Environment                    (getArgs)
 
 getLatestRevision :: String -> IO Integer
 getLatestRevision package =
@@ -18,7 +27,19 @@ getPackageRevision package revision =
   (^. responseBody) <$> get uri
   where uri = "http://hackage.haskell.org/package/" ++ package ++ "/revision/" ++ show revision
 
+parseCabal :: ByteString -> Either String [String]
+parseCabal file =
+  case parsePackageDescription (L.unpack file) of
+      ParseOk _ info -> case condLibrary info of
+                            Just lib -> Right $ dependencyName <$> condTreeConstraints lib
+                            Nothing -> Left "Package is not a library."
+      ParseFailed e -> Left $ show e
+  where dependencyName (Dependency name _) = unPackageName name
+
 main :: IO ()
 main = do
   package <- head <$> getArgs
-  getLatestRevision package >>= getPackageRevision package >>= print
+  getLatestRevision package >>= getPackageRevision package >>= display . parseCabal
+  where display ds = case ds of
+                         Left e -> error e
+                         Right ds' -> forM_ ds' putStrLn

--- a/extract-dependencies/stack.yaml
+++ b/extract-dependencies/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-3.15
+packages:
+- '.'
+extra-deps: []
+extra-package-dbs: []

--- a/file-modules
+++ b/file-modules
@@ -1,3 +1,0 @@
-#!/bin/bash
-cat $1 |
-grep -Po "import +(qualified +)?\K([^\s]+)"

--- a/file-modules/.gitignore
+++ b/file-modules/.gitignore
@@ -1,0 +1,20 @@
+# Created by https://www.gitignore.io/api/haskell
+
+### Haskell ###
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+.stack-work/
+

--- a/file-modules/LICENSE
+++ b/file-modules/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015 Pedro Tacla Yamada
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/file-modules/Setup.hs
+++ b/file-modules/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/file-modules/file-modules.cabal
+++ b/file-modules/file-modules.cabal
@@ -1,0 +1,21 @@
+name: file-modules
+version: 0.1.0.0
+synopsis: Takes a Haskell source-code file and outputs the module it
+        . imports. Follows links to local modules as well.
+-- description:
+homepage: https://github.com/yamadapc/stack-run-auto
+license: MIT
+license-file: LICENSE
+author: Pedro Tacla Yamada
+maintainer: tacla.yamada@gmail.com
+copyright: Copyright (c) Pedro Tacla Yamada 2015
+category: Development
+build-type: Simple
+cabal-version: >=1.10
+
+executable file-modules
+  main-is: Main.hs
+  build-depends: base >=4.5 && <5
+               , haskell-src-exts >= 1.17 && < 2
+  hs-source-dirs: src
+  default-language: Haskell2010

--- a/file-modules/src/Main.hs
+++ b/file-modules/src/Main.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RecordWildCards #-}
+module Main where
+
+import           Control.Monad         (forM_)
+import           Language.Haskell.Exts (ImportDecl (..),
+                                        ModuleHeadAndImports (..),
+                                        ModuleName (..), NonGreedy (..),
+                                        ParseResult (..), parse)
+import           System.Environment    (getArgs)
+import           System.Exit           (exitFailure)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    forM_ args fileModules
+
+fileModules :: FilePath -> IO ()
+fileModules fname = do
+    result <- parse <$> readFile fname
+    case result of
+        (ParseOk (NonGreedy{..})) -> do
+            let (ModuleHeadAndImports _ _ mimports) = unNonGreedy
+            forM_ mimports $ \imp ->
+                let ModuleName iname = importModule imp
+                in putStrLn iname
+        (ParseFailed _ _) -> exitFailure

--- a/file-modules/stack.yaml
+++ b/file-modules/stack.yaml
@@ -1,0 +1,13 @@
+flags:
+  text:
+    integer-simple: false
+packages:
+- '.'
+extra-deps:
+- cpphs-1.19.3
+- haskell-src-exts-1.17.0
+- old-locale-1.0.0.7
+- old-time-1.1.0.3
+- polyparse-1.11
+- text-1.2.1.3
+resolver: ghc-7.10


### PR DESCRIPTION
I wrote a small haskell application to replace `extract-dependencies-simple` which:
- Retrieves the newest revision of the latest version of a given package from Hackage;
- downloads the corresponding cabal file;
- parses the file and list the required packages.
##### Example usage:

``` bash
$ stack exec extract-dependencies yesod 
base
yesod-core
yesod-auth
yesod-persistent
yesod-form
monad-control
transformers
wai
wai-extra
warp
blaze-html
blaze-markup
aeson
safe
data-default
unordered-containers
yaml
text
directory
template-haskell
bytestring
monad-logger
fast-logger
conduit-extra
shakespeare
streaming-commons
wai-logger
semigroups
```
